### PR TITLE
KYP-694: Update swagger docs

### DIFF
--- a/metrilo_open_api_specification.yml
+++ b/metrilo_open_api_specification.yml
@@ -701,14 +701,6 @@ components:
           type: object
           description: Order's billing information.
           properties:
-            firstName:
-              type: string
-              description: Customer's first name.
-              example: Johny
-            lastName:
-              type: string
-              description: Customer's last name.
-              example: Bravo
             address:
               type: string
               description: Full billing address.


### PR DESCRIPTION

Jira story [#KYP-694](https://metrilojira.atlassian.net/browse/KYP-694) in project *Know Your Power*:

> In the order info there is a field billing containing firstName and lastName. However, even though they are sent, the new tracking don't send them to the Monolith. Looks like they are redundant and is better to be deleted, so customers are not wondering what happens with them. 
> Check why does the new tracking omit parsing the names(maybe it is a bug/feature?).