### PR TITLE
KYP-1840: Add phone number to the integrateFrom script and the customerDetails endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Customer has entered their details on a web form. This call updates the first na
   const params = {
     firstName: 'Johny', // Customer's first name (optional)
     lastName: 'Bravo', // Customer's last name (optional)
+    phoneNumber: '+46 100 200', // Phone number (optional)
     subscribed: false // Subscribed status - true or false (optional)
   }
 
@@ -348,6 +349,7 @@ You can integrate a form (such as a newsletter subscription form) with Metrilo u
     email: 'newsletter[fields][1]', // required - the name attribute of the "email" input field
     firstName: 'newsletter[fields][0][first]', // optional - the name attribute of the "first name" input field
     lastName: 'newsletter[fields][0][last]', // optional - the name attribute of the "last name" input field
+    phoneNumber: 'newsletter[fields][0][first]', // optional - the name attribute of the "phone number" field
     subscribed: 'newsletter[fields][2][]', // optional - the name attribute of the "subscribed"  checkbox
     tags: ['newsletter-subscriber'], // optional - an array of tags to be applied
     customEvent: 'newsletter-subscribed' // optional - a custom event to be sent

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ You can integrate a form (such as a newsletter subscription form) with Metrilo u
     email: 'newsletter[fields][1]', // required - the name attribute of the "email" input field
     firstName: 'newsletter[fields][0][first]', // optional - the name attribute of the "first name" input field
     lastName: 'newsletter[fields][0][last]', // optional - the name attribute of the "last name" input field
-    phoneNumber: 'newsletter[fields][0][first]', // optional - the name attribute of the "phone number" field
+    phoneNumber: 'newsletter[fields][3]', // optional - the name attribute of the "phone number" field
     subscribed: 'newsletter[fields][2][]', // optional - the name attribute of the "subscribed"  checkbox
     tags: ['newsletter-subscriber'], // optional - an array of tags to be applied
     customEvent: 'newsletter-subscribed' // optional - a custom event to be sent


### PR DESCRIPTION


Jira story [#KYP-1840](https://metrilojira.atlassian.net/browse/KYP-1840) in project *Know Your Power*:

> From ticket KYP-1734 it was decided to add phone field in the customerDetails endpoint and the integrateForm for the new and old tracking.
> 
> The old tracking integrateForm is using the old identify call, which already support passing phone field. So, just add the phone as param
> 
> The new tracking integrateForm is using customerDetails, which resolve to the old identify call. So, add the param to the endpoint possible params (don't forget the documentation) and use it in the form