### PR TITLE
Add tag/untag customer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,37 @@ All calls to these endpoints have to be done from your backend - therefore, we d
 
 :information_source: Note that each request you send to Metrilo is limited to **5MB** in size.
 
+### Tag / Untag customer
+You can tag or untag existing Metrilo customers by calling the following endpoints from your backend.
+
+| Endpoint           | Usage                                                               |
+| :----------------- | :-------------------------------------------------------------------|
+| /customer/tag      | Adds tags to an existing customer (tags are merged, not overwritten)|
+| /customer/untag    | Removes tags from an existing customer (missing tags are omitted)   |
+
+#### Tag a customer
+
+```bash
+$ echo -n '{"time": 1518004715732, "token": "sh0p-t0k3n", "params": {"email": "test@metrilo.com", "tags": ["foo"]} }' | openssl dgst sha256 -hmac 'm3trilo-secr3t'
+ac9600a205af6aea7be1a4a3f8044d80fb9f4fb84ce9b550265650beefb12e4a
+
+curl -X POST "https://trk.mtrl.me/v2/customer/tag" -i -H "Content-Type: text/plain" -H "X-Digest: ac9600a205af6aea7be1a4a3f8044d80fb9f4fb84ce9b550265650beefb12e4a" -d '{"time": 1518004715732, "token": "sh0p-t0k3n", "params": {"email": "test@metrilo.com", "tags": ["foo"]} }'
+
+```
+
+#### Untag a customer
+
+```bash
+$ echo -n '{"time": 1518004715732, "token": "sh0p-t0k3n", "params": {"email": "test@metrilo.com", "tags": ["foo"]} }' | openssl dgst sha256 -hmac 'm3trilo-secr3t'
+a2fc3d7dbe351311b433a1cf54edf59ef96885f0dcd1ede6e508a5ceb4c98a89
+
+curl -X POST "https://trk.mtrl.me/v2/customer/untag" -i -H "Content-Type: text/plain" -H "X-Digest: a2fc3d7dbe351311b433a1cf54edf59ef96885f0dcd1ede6e508a5ceb4c98a89" -d '{"time": 1518004715732, "token": "sh0p-t0k3n", "params": {"email": "test@metrilo.com", "tags": ["foo"]} }'
+
+```
+
+
+:information_source: The `X-Digest` header **must** be used here as well.
+
 ### Importing resources
 
 Before sending any [tracking events](#tracking-events) to Metrilo, you need to import your data using the endpoints provided for each resource. **Note that importing must be done in the order provided.** You can find more details for each endpoint in the [documentation](https://app.swaggerhub.com/apis/metrilo/api/2.0.1).

--- a/metrilo_open_api_specification.yml
+++ b/metrilo_open_api_specification.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 1.0.0
+  version: 2.1.1
   title: Metrilo tracking API
   description: Metrilo analytics tracking API
   contact:
@@ -80,6 +80,60 @@ paths:
           text/plain:
             schema:
               $ref: '#/components/schemas/customerOperationObject'
+      responses:
+        '200':
+          $ref: '#/components/responses/success'
+        '400':
+          $ref: '#/components/responses/errorBadRequest'
+        '401':
+          $ref: '#/components/responses/errorUnauthorized'
+        '402':
+          $ref: '#/components/responses/errorPaymentRequired'
+        '403':
+          $ref: '#/components/responses/errorForbidden'
+        '500':
+          $ref: '#/components/responses/internalServerError'
+        '502':
+          $ref: '#/components/responses/badGateway'
+  /customer/tag:
+    post:
+      tags:
+        - API
+      description: Adds tags to an existing customer in Metrilo.
+      operationId: customerTagOperation
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              $ref: '#/components/schemas/customerTagOperationObject'
+      responses:
+        '200':
+          $ref: '#/components/responses/success'
+        '400':
+          $ref: '#/components/responses/errorBadRequest'
+        '401':
+          $ref: '#/components/responses/errorUnauthorized'
+        '402':
+          $ref: '#/components/responses/errorPaymentRequired'
+        '403':
+          $ref: '#/components/responses/errorForbidden'
+        '500':
+          $ref: '#/components/responses/internalServerError'
+        '502':
+          $ref: '#/components/responses/badGateway'
+  /customer/untag:
+    post:
+      tags:
+        - API
+      description: Removes tags from an existing customer in Metrilo.
+      operationId: customerUntagOperation
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              $ref: '#/components/schemas/customerUntagOperationObject'
       responses:
         '200':
           $ref: '#/components/responses/success'
@@ -314,7 +368,49 @@ components:
               type: array
               items:
                   type: string
-                  description: Tag labels that are assigned to users in the Metrilo application. (tags are merged, not overwritten)
+                  description: Tag labels that are assigned to the customer in Metrilo. (tags are merged, not overwritten)
+                  example:
+                    - early_subscriber
+                    - big_spender
+    customerTagObject:
+      allOf:
+        - $ref: '#/components/schemas/visitorIdentityObject'
+        - type: object
+          required:
+            - createdAt
+            - email
+            - tags
+          properties:
+            email:
+              type: string
+              description: The email of the customer.
+              example: johnybravo@metrilo.com
+            tags:
+              type: array
+              items:
+                  type: string
+                  description: Tag labels that are assigned to the customer in Metrilo. (tags are merged, not overwritten)
+                  example:
+                    - early_subscriber
+                    - big_spender
+    customerUntagObject:
+      allOf:
+        - $ref: '#/components/schemas/visitorIdentityObject'
+        - type: object
+          required:
+            - createdAt
+            - email
+            - tags
+          properties:
+            email:
+              type: string
+              description: The email of the customer.
+              example: johnybravo@metrilo.com
+            tags:
+              type: array
+              items:
+                  type: string
+                  description: Tag labels that are removed from the customer in Metrilo. (missing tags are omitted)
                   example:
                     - early_subscriber
                     - big_spender
@@ -519,6 +615,26 @@ components:
             params:
               allOf:
                 - $ref: '#/components/schemas/customerObject'
+    customerTagOperationObject:
+      allOf:
+        - $ref: '#/components/schemas/basicBackendObject'
+        - type: object
+          required:
+            - params
+          properties:
+            params:
+              allOf:
+                - $ref: '#/components/schemas/customerTagObject'
+    customerUntagOperationObject:
+      allOf:
+        - $ref: '#/components/schemas/basicBackendObject'
+        - type: object
+          required:
+            - params
+          properties:
+            params:
+              allOf:
+                - $ref: '#/components/schemas/customerUntagObject'
     customerBatchOperationObject:
       allOf:
         - $ref: '#/components/schemas/basicBackendObject'


### PR DESCRIPTION
Adding the tag/untag and bumping the docs version to `2.1.1`. 



===

Jira story [#KYP-1894](https://metrilojira.atlassian.net/browse/KYP-1894) in project *Know Your Power*:

> Implement backend endpoints for tag/untag customers. 